### PR TITLE
Upgrades, fix-ups, enhancements & tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ After completing the installation described below, you will control a complete a
 
 ## Steps to install
 
+Feel free to also download and take a look at a WEBM [video](https://github.com/haqer1/k8s-spring_boot-elastic-kibana-graphana-demo/raw/refs/heads/master/assets/k8s-spring_boot-elastic-kibana-graphana-demo.webm "WEBM video") providing an illustration of the steps below.
+
 ### Create a Cluster on Minikube
 
 This guide assumes that you have VirtualBox installed on your computer or a similar virtualization software.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# k8s-showcase
+# k8s-demo
 
 This showcase highlights the following key concepts for deploying Spring Boot applications to a Kubernetes cluster:
 
@@ -21,25 +21,32 @@ After completing the installation described below, you will control a complete a
 
 This guide assumes that you have VirtualBox installed on your computer or a similar virtualization software.
 Install [minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/ "Minukube") on your local machine.
-Create a cluster with the following parameters:
+Create a cluster with the following parameters (FYI: this demo has used about 12GB of disk space):
 
-	minikube start -p k8s-showcase --memory='8192mb' --disk-size='16384mb' --vm-driver=virtualbox
+	minikube start -p k8s-demo --memory='4096mb'
+
+or
+
+	minikube start -p k8s-demo --memory='4096mb' --disk-size='13632mb'
  
 You should see an output like this:
 
-	* Creating virtualbox VM (CPUs=2, Memory=8192MB, Disk=16384MB) ...
-	* Preparing Kubernetes v1.18.0 on Docker 19.03.8 ...
-	* Enabling addons: default-storageclass, storage-provisioner
-	* Done! kubectl is now configured to use "k8s-showcase"
+	🐳  Preparing Kubernetes v1.32.0 on Docker 27.4.1 ...
+	...
+	🔥  Creating docker container (CPUs=2, Memory=4096MB) ...
+	...
+	🌟  Enabled addons: storage-provisioner, default-storageclass
+	...
+	🏄  Done! kubectl is now configured to use "k8s-demo" cluster and "default" namespace by default
 
-Make sure that k8s-showcase is your current minikube profile. Execute `minikube profile k8s-showcase` and then verify the current profile with `minikube profile`.
-You should see `* k8s-showcase` as confirmation.
+Making sure that k8s-demo is your current minikube profile might simplify things: execute `minikube profile k8s-demo` and then verify the current profile with `minikube profile`.
+You should see `* k8s-demo` as confirmation.
 
 ### Start the Kubernetes Dashboard
 
 The Kubernetes Dashboard is very useful when it comes to to track and monitor what is happening your cluster. Open a new command window or shell and start the Kubernetes Dashbord with `minikube dashboard`. This will open your Browser showing the inital Dashboard screen.
 
-Next check the IP address which is assigned to your cluster with `minikube ip`. You will get a response like `192.168.99.104`. Keep this IP address in mind or even better add it as host name `k8s-showcase` to `C:\Windows\System32\drivers\etc\hosts` (You need admin permission to do this). You will need it later to access the apps running inside the cluster.
+Next check the IP address which is assigned to your cluster with `minikube ip`. You will get a response like `192.168.99.104`. Keep this IP address in mind or even better add it as host name `k8s-demo` to `C:\Windows\System32\drivers\etc\hosts` (You need admin permission to do this). You will need it later to access the apps running inside the cluster.
  
 ### Deploy the Application Stack
 
@@ -72,17 +79,14 @@ This will apply all deployment files (*.k8s.yml) in the `k8s-deployment` directo
 	deployment.apps/prometheus created
 	service/prometheus created
 	clusterrolebinding.rbac.authorization.k8s.io/admin-default created
-	configmap/k8s-be created
-	deployment.apps/k8s-be created
-	service/k8s-be created
-	service/k8s-be-management created
-	deployment.apps/k8s-bff created
-	service/k8s-bff created
-	service/k8s-bff-management created
-	configmap/k8s-sba created
-	deployment.apps/k8s-sba created
-	service/k8s-sba created
-	service/k8s-sba-management created
+	configmap/k8s-demo-be created
+	deployment.apps/k8s-demo-be created
+	service/k8s-demo-be created
+	deployment.apps/k8s-demo-bff created
+	service/k8s-demo-bff created
+	configmap/k8s-demo-sba created
+	deployment.apps/k8s-demo-sba created
+	service/k8s-demo-sba created
 
 ### Verify Deployment
 
@@ -90,34 +94,35 @@ After a few minutes the cluster should have started all pods. Check the dashboar
 
 ![Kubernetes Dashboard](screenshots/dashboard.png "Kubernetes Dashboard") 
 
-You can now visit the installed apps by using the following links: (The hostname `k8s-showcase` should point to your cluster ip address)
+You can now visit the installed apps by using the following links: (The hostname `k8s-demo` should point to your cluster ip address)
 
 | URL                                  | Description                                                                                             |
 |--------------------------------------|---------------------------------------------------------------------------------------------------------|
-| <http://k8s-showcase:30001?name=Max> | Request to the backend (k8s-be). This will return a simmple message. It will also generate log message  |
-| <http://k8s-showcase:30002?name=Max> | Request to the backend-for-frontend (k8s-bff). This will query the backend for a message and return it. |
-| <http://k8s-showcase:30003>          | Opens the Spring Boot Admin UI                                                                          |
-| <http://k8s-showcase:30004>          | Opens the Kibana UI                                                                                     |
-| <http://k8s-showcase:30005>          | Opens the Prometheus Admin UI                                                                           |
-| <http://k8s-showcase:30006>          | Opens the Grafana UI (Use admin/admin for first login)                                                  |
+| <http://k8s-demo:30001?name=Resat> | Request to the backend (k8s-demo-be). This will return a simple message. It will also generate an ERROR-level log message with ID as example. |
+| <http://k8s-demo:30002?name=Resat> | Request to the backend-for-frontend (k8s-demo-bff). This will query the backend for a message and return it.                                  |
+| <http://k8s-demo:30001/tip>        | Request to another backend operation (k8s-demo-be). This will return a different message & generate an INFO-level log message with a marker.  |
+| <http://k8s-demo:30003>          | Opens the Spring Boot Admin UI                                                                          |
+| <http://k8s-demo:30004>          | Opens the Kibana UI                                                                                     |
+| <http://k8s-demo:30005>          | Opens the Prometheus Admin UI                                                                           |
+| <http://k8s-demo:30006>          | Opens the Grafana UI (Use admin/admin for first login)                                                  |
 
-#### The Spring Boot Backend (k8s-be)
+#### The Spring Boot Backend (k8s-demo-be)
 
-The backend is a simple REST service which will return the message "Message in a bottle" upon request. You can provide a name as parameter. The message text is configured as Kubernetes ConfigMap and can be changed without a restart. This is achieved using [Spring Cloud Kubernetes](https://spring.io/projects/spring-cloud-kubernetes) and Spring Boot's `@RefreshScope` annotation. (See deployment file `spring-boot-apps.k8s.yml`)
+The backend is a simple REST service which will return a message dependent on Spring active profile(s) like "Development-specific config message ..." upon request (or "Message from embedded application.yml ..." if ConfigMap-based config is not functional). You have to provide a name parameter. The message text is configured via a Kubernetes ConfigMap and can be changed without a restart (or redeployment). This is achieved using [Spring Cloud Kubernetes](https://spring.io/projects/spring-cloud-kubernetes) and Spring Boot's `@RefreshScope` annotation. (See deployment file `spring-boot-apps.k8s.yml`)
 
 ![Spring Boot backend](screenshots/be-response.png "Spring Boot backend") 
 
 Calling this service will also produce log and metrics data which can be analyzed later.
 
-#### The Spring Boot Backend (k8s-bff)
+#### The Spring Boot Backend-for-frontend (k8s-demo-bff)
 
-The backend-for-frontend uses a [Feign Client](https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-feign.html) which queries the backend for messages. The Feign Client is annotated with `@FeignClient(url = "http://k8s-be")` and automatically finds the backend with the service object's name `k8s-be`
+The backend-for-frontend uses a [Feign Client](https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-feign.html) which queries the backend for messages. The Feign Client is annotated with `@FeignClient(url = "http://k8s-demo-be")` and automatically finds the backend with the service object's name `k8s-demo-be` (this is more tricky if Docker is in rootles mode).
 
 ![Spring Boot backend-for-frontend](screenshots/bff-response.png "Spring Boot backend-for-frontend")
 
 Both Spring Boot applications provide a full set of [actuator endpoints](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html) which will be used by the following monitoring tools. 
 
-#### Spring Boot Admin (k8s-sba)
+#### Spring Boot Admin (k8s-demo-sba)
 
 The Spring Boot Admin application is used to gather build, configuration and health status information of the Spring Boot apps. It uses the discovery client provided with [Spring Cloud Kubernetes](https://spring.io/projects/spring-cloud-kubernetes) and scans the Kubernetes API for service objects with the label `sba-monitored: "true"`.
 
@@ -125,11 +130,11 @@ The Spring Boot Admin application is used to gather build, configuration and hea
 
 #### Kibana
 
-Kibana is a powerful tool to analyze data provided by ElasticSearch. As first step you must make the log index available for searching: Select `Discover` from the menu. Then create an index pattern with `fluentd-*` and select `@timestamp` as time field. Now you can search through the logs. Enter `kubernetes.labels.app: k8s-be AND level:ERROR` as filter and click Refresh. You should see the error log entries created by the Spring Boot app `k8s-be`.
+Kibana is a powerful tool to analyze data provided by ElasticSearch. As first step you must make the log index available for searching: Select `Discover` from the menu. Then create an index pattern with `fluentd-*` and select `@timestamp` as time field. Now you can search through the logs. Enter `kubernetes.labels.app: k8s-demo-be AND level:ERROR` as filter and click Refresh. You should see the error log entries created by the Spring Boot app `k8s-demo-be`.
 
 ![Kibana Filter](screenshots/kibana_filter.png "Kibana Filter") 
 
-The log messages produced by the Spring Boot apps are written as JSON to stdout. This is the most efficient way to forward it to the fluentd log daemon, because there is no further parsing required. Additionally, log messages with multiple lines (like the Java stacktrace shown below) do not impose any problems as it might happen with unstructured text output.
+The log messages produced by the Spring Boot apps are written as JSON to stdout. This is the most efficient way to forward it to the fluentd log daemon, because there is no further parsing required. Additionally, log messages with multiple lines (like the Java stacktrace shown below) do not pose any problems as it might happen with unstructured text output.
 
 ![Spring Boot Log Entry Details](screenshots/kibana_log.png "Spring Boot Log Entry Details") 
  	
@@ -141,7 +146,7 @@ Prometheus is a database for storing multi dimensional metrics based on a time l
   
 #### Grafana
 
-With Grafana you can analyze and visualize the data provided by Prometheus and ElasticSearch. First define a datasource for Prometheus using `http://prometheus:9090`. Now create a dashboard and add chart with the PromQL expression `rate(http_server_requests_seconds_count{app="k8s-be"}[1m])`. This will give you visualization of HTTP server requests per second for the Spring Boot app `k8s-be`.  
+With Grafana you can analyze and visualize the data provided by Prometheus and ElasticSearch. First define a datasource for Prometheus using `http://prometheus:9090`. Now create a dashboard and add chart with the PromQL expression `rate(http_server_requests_seconds_count{app="k8s-demo-be"}[1m])`. This will give you visualization of HTTP server requests per second for the Spring Boot app `k8s-demo-be`.
 
 ![Grafana/Prometheus](screenshots/grafana_prometheus.png "Grafana/Prometheus")
  

--- a/k8s-be/pom.xml
+++ b/k8s-be/pom.xml
@@ -6,18 +6,24 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.2</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<version>3.4.4</version>
+		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>ch.martin.k8s</groupId>
-	<artifactId>k8s-be</artifactId>
-	<version>1.1.0</version>
-	<name>k8s-app</name>
+	<artifactId>k8s-demo-be</artifactId>
+	<version>1.3.19</version>
+	<name>k8s-demo-be</name>
 	<description>Backend</description>
 
 	<properties>
-		<java.version>11</java.version>
-		<spring-cloud.version>2020.0.0</spring-cloud.version>
+		<k8s-demo.image.hosting.account.url>docker.io/adazes</k8s-demo.image.hosting.account.url>
+
+		<java.version>21</java.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<spring-cloud.k8s.version>3.2.1</spring-cloud.k8s.version>
+		<logstash.version>8.0</logstash.version>
+		<lombok.version>1.18.36</lombok.version>
+		<git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -25,10 +31,22 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+<!--
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
+			<artifactId>spring-cloud-kubernetes-fabric8-leader</artifactId>
+			<version>${spring-cloud.k8s.version}</version>
+		</dependency> -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-kubernetes-fabric8-config</artifactId>
+			<version>${spring-cloud.k8s.version}</version>
 		</dependency>
+<!--	<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
+			<version>${spring-cloud.k8s.version}</version>
+		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -40,7 +58,7 @@
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
-			<version>6.3</version>
+			<version>${logstash.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -61,6 +79,22 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.17.0</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>3.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>8.0.2.Final</version>
 		</dependency>
 	</dependencies>
 
@@ -92,14 +126,15 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
+				<version>${git-commit-id-plugin.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-				<version>2.7.1</version>
+				<version>3.4.5</version>
 				<configuration>
 					<to>
-						<image>gcr.io/handy-zephyr-272321/${project.artifactId}:${project.version}</image>
+						<image>${k8s-demo.image.hosting.account.url}/${project.artifactId}:${project.version}</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/k8s-be/src/main/java/ch/martin/k8s/be/BurnBabyBurn.java
+++ b/k8s-be/src/main/java/ch/martin/k8s/be/BurnBabyBurn.java
@@ -3,13 +3,13 @@ package ch.martin.k8s.be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@ComponentScan({"ch.martin.k8s.be", "com.adazes.k8s.demo.be.controller"})
 public class BurnBabyBurn {
-
 	public static void main(String[] args) {
 		SpringApplication.run(BurnBabyBurn.class, args);
 	}
-
 }

--- a/k8s-be/src/main/java/ch/martin/k8s/be/GreetingController.java
+++ b/k8s-be/src/main/java/ch/martin/k8s/be/GreetingController.java
@@ -1,40 +1,50 @@
 package ch.martin.k8s.be;
 
-import static net.logstash.logback.argument.StructuredArguments.keyValue;
-
-import java.time.LocalDateTime;
-
+import com.adazes.k8s.demo.be.dto.SpringInfoDto;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.core.SpringVersion;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+
+import static net.logstash.logback.argument.StructuredArguments.keyValue;
 
 @RestController
 @RefreshScope
 @Slf4j
 public class GreetingController {
-
+	private static final String MESSAGE_PATTERN = "{0} to {1} from the K8S demo backend!";
 	private final String appName;
 	private final String message;
 	private int messageId = 1000;
+	private final String env;
+	private final BuildProperties buildProperties;
 
-	public GreetingController(@Value("${spring.application.name}") @NonNull String appName,
-			@Value("${k8s-be.message}") @NonNull String message) {
+	public GreetingController(@Autowired @NonNull BuildProperties buildProperties,
+		  	@Value("${spring.application.name}") @NonNull String appName,
+			@Value("${k8s-demo.be.message}") @NonNull String message,
+			@Value("${spring.profiles.active}") String env) {
+		this.buildProperties = buildProperties;
 		this.appName = appName;
 		this.message = message;
+		this.env = env;
 	}
 
 	@GetMapping("/")
 	public GreetingDto getGreeting(@RequestParam("name") String name) {
-		String returnedMessage = message + " to " + name + " from the K8S backend (version 1.1.0)! Time: "
-				+ LocalDateTime.now();
-		log.info("{} will return message: {}, messageId = {}", appName, message, keyValue("messageId", messageId++));
-		log.error("Just another ugly error. But the stack trace will save your day.", new Exception("An Exception"));
-		return new GreetingDto(returnedMessage);
+		String returnedMessage = MessageFormat.format(MESSAGE_PATTERN, message, name);
+		log.error("Just another ugly error in {}. But the stack trace will save your day. {}"
+				, appName, keyValue("messageId", messageId++), new Exception("An Exception"));
+		return new GreetingDto(returnedMessage, buildProperties.getVersion(), LocalDateTime.now()
+			, new SpringInfoDto(SpringVersion.getVersion(), env, SpringBootVersion.getVersion()));
 	}
-
 }

--- a/k8s-be/src/main/java/ch/martin/k8s/be/GreetingDto.java
+++ b/k8s-be/src/main/java/ch/martin/k8s/be/GreetingDto.java
@@ -1,9 +1,12 @@
 package ch.martin.k8s.be;
 
+import com.adazes.k8s.demo.be.dto.SpringInfoDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -11,5 +14,8 @@ import lombok.Setter;
 @AllArgsConstructor
 public class GreetingDto {
 
-	public String message;
+	private String message;
+	private String appVersion;
+	private LocalDateTime now;
+	private SpringInfoDto spring;
 }

--- a/k8s-be/src/main/java/com/adazes/k8s/demo/be/controller/TipOfTheDayController.java
+++ b/k8s-be/src/main/java/com/adazes/k8s/demo/be/controller/TipOfTheDayController.java
@@ -1,0 +1,53 @@
+package com.adazes.k8s.demo.be.controller;
+
+import com.adazes.k8s.demo.be.dto.TipDto;
+import com.adazes.k8s.demo.be.util.MarkerPool;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * A prototype of a ReST endpoint providing (tech) tip of the day.
+ *
+ * @author  Resat SABIQ
+ * @since   1.3.19
+ */
+@RestController
+@RequestMapping("tip")
+@RefreshScope
+@Slf4j
+public class TipOfTheDayController {
+    private final String tip, learnMoreRef;
+
+    /**
+     *
+     * @param tip           the tip presently configured (auto-refreshable)
+     * @param learnMoreRef  (hyper-)reference to learn more (optional)
+     */
+    public TipOfTheDayController(@Value("${k8s-demo.be.tip.summary}") @NonNull String tip
+    , @Value("${k8s-demo.be.tip.learn-more-ref}") @Nullable String learnMoreRef) {
+        this.tip = tip;
+        this.learnMoreRef = learnMoreRef;
+    }
+
+    /**
+     * Default mapping for the tip of the day. Logs an INFO message with {@link MarkerPool#GOOD_TO_KNOW} marker &amp;
+     * remote address.
+     *
+     * @param req   request used to look up the remote address of requester
+     *
+     * @return  the tip
+     */
+    @GetMapping("")
+    public TipDto getTip(HttpServletRequest req) {
+        TipDto tipDto = new TipDto(tip, learnMoreRef);
+        log.info(MarkerPool.GOOD_TO_KNOW, "Returning to {}: {}", req.getRemoteAddr(), tipDto);
+        return tipDto;
+    }
+}

--- a/k8s-be/src/main/java/com/adazes/k8s/demo/be/dto/SpringInfoDto.java
+++ b/k8s-be/src/main/java/com/adazes/k8s/demo/be/dto/SpringInfoDto.java
@@ -1,0 +1,26 @@
+package com.adazes.k8s.demo.be.dto;
+
+import jakarta.validation.constraints.NotNull;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Spring info DTO.
+ *
+ * @param version   Spring version
+ * @param profiles  profile(s) active (optional)
+ * @param springBootVersion Spring Boot version (optional)
+ *
+ * @author  Resat SABIQ
+ * @since   1.3.19
+ */
+public record SpringInfoDto(@NotNull String version, String profiles, String springBootVersion) {
+    public static final String DEFAULT_PROFILE = "(default)";
+
+    /**
+     * Defaults {@link #profiles} to {@link #DEFAULT_PROFILE} if blank.
+     */
+    public SpringInfoDto {
+        if (StringUtils.isBlank(profiles))
+            profiles = DEFAULT_PROFILE;
+    }
+}

--- a/k8s-be/src/main/java/com/adazes/k8s/demo/be/dto/TipDto.java
+++ b/k8s-be/src/main/java/com/adazes/k8s/demo/be/dto/TipDto.java
@@ -1,0 +1,26 @@
+package com.adazes.k8s.demo.be.dto;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Tip DTO.
+ *
+ * @param tip           tip of the day
+ * @param learnMoreRef  (hyper-)reference to learn more
+ *
+ * @author  Resat SABIQ
+ * @since   1.3.19
+ */
+public record TipDto(@NotNull String tip, @Nullable String learnMoreRef) {
+    /**
+     * Convenience constructor (e.g., for default config (defaulting {@link #learnMoreRef} to {@code null}))
+     *
+     * @param tip   the tip
+     * @see TipDto#TipDto(String, String)
+     */
+    @SuppressWarnings("unused")
+    public TipDto(@NotNull String tip) {
+        this(tip, null);
+    }
+}

--- a/k8s-be/src/main/java/com/adazes/k8s/demo/be/util/MarkerPool.java
+++ b/k8s-be/src/main/java/com/adazes/k8s/demo/be/util/MarkerPool.java
@@ -1,0 +1,17 @@
+package com.adazes.k8s.demo.be.util;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+/**
+ * App-wide pool of markers.
+ *
+ * @author  Resat SABIQ
+ * @since   1.3.19
+ */
+public class MarkerPool {
+    /**
+     * For filtering logging messages with extra general utility.
+     */
+    public static final Marker GOOD_TO_KNOW = MarkerFactory.getMarker("GOOD_TO_KNOW");
+}

--- a/k8s-be/src/main/resources/application.yml
+++ b/k8s-be/src/main/resources/application.yml
@@ -9,5 +9,25 @@ management:
         include: "*"
   endpoint:
     health:
-      show-details: ALWAYSk8s-be:
-  message: "Message from embedded application.yml"
+      show-details: ALWAYS
+spring: # Merged from deprecated & removed bootstrap.yml
+  application:
+    name: k8s-demo-be
+  config:
+    import: "kubernetes:"
+  cloud:
+    kubernetes:
+      reload:
+        enabled: true
+        mode: event
+# Optional here because it's matched by default, but shows an example of an advanced config possible:
+#     config: 
+#       sources:
+#         - name: k8s-demo-be
+#           namespace: k8s-spring-boot-apps
+k8s-demo:
+  be:
+    message: "Message from embedded application.yml"
+    tip:
+      summary: Did you know that Java HttpClient makes a new connection to server immediately after an IOException?
+      learn-more-ref:

--- a/k8s-be/src/main/resources/bootstrap.yml
+++ b/k8s-be/src/main/resources/bootstrap.yml
@@ -1,8 +1,0 @@
-spring: 
-  application:
-    name: k8s-be
-  cloud:
-    kubernetes:
-      reload:
-        enabled: true
-        mode: event

--- a/k8s-be/src/main/resources/logback-spring.xml
+++ b/k8s-be/src/main/resources/logback-spring.xml
@@ -9,4 +9,6 @@
     <root level="INFO">
         <appender-ref ref="consoleAppender"/>
     </root>
+    <logger name="io.fabric8" level="DEBUG" />
+    <logger name="org.springframework.cloud.kubernetes.fabric8" level="DEBUG" />
 </configuration>

--- a/k8s-bff/pom.xml
+++ b/k8s-bff/pom.xml
@@ -1,22 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.2</version>
+		<version>3.4.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>ch.martin.k8s</groupId>
-	<artifactId>k8s-bff</artifactId>
-	<version>1.1.0</version>
-	<name>k8s-bff</name>
+	<artifactId>k8s-demo-bff</artifactId>
+	<version>1.3.19</version>
+	<name>k8s-demo-bff</name>
 	<description>Backend for frontend</description>
 
 	<properties>
-		<java.version>11</java.version>
-		<spring-cloud.version>2020.0.0</spring-cloud.version>
+		<k8s-demo.image.hosting.account.url>docker.io/adazes</k8s-demo.image.hosting.account.url>
+
+		<java.version>21</java.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<spring-cloud.k8s.version>3.2.1</spring-cloud.k8s.version>
+		<logstash.version>8.0</logstash.version>
+		<lombok.version>1.18.36</lombok.version>
+		<git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -39,11 +46,12 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
+			<version>${spring-cloud.k8s.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
-			<version>6.3</version>
+			<version>${logstash.version}</version>
 		</dependency>
 
 		<dependency>
@@ -55,6 +63,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -98,14 +107,15 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
+				<version>${git-commit-id-plugin.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-				<version>2.7.1</version>
+				<version>3.4.5</version>
 				<configuration>
 					<to>
-						<image>gcr.io/handy-zephyr-272321/${project.artifactId}:${project.version}</image>
+						<image>${k8s-demo.image.hosting.account.url}/${project.artifactId}:${project.version}</image>
 					</to>
 				</configuration>
 			</plugin>

--- a/k8s-bff/src/main/java/ch/martin/k8s/bff/BackendClient.java
+++ b/k8s-bff/src/main/java/ch/martin/k8s/bff/BackendClient.java
@@ -5,9 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
- * A REST client for the backend. The value of 'url' must match the name of the service object for k8s-be defined in Kubernetes.
+ * A REST client for the backend. The value of 'url' must match the name of the service object for
+ * k8s-demo-be defined in Kubernetes config.
  */
-@FeignClient(name = "k8s-be", url = "http://k8s-be")
+@FeignClient(name = "k8s-demo-be", url = "http://k8s-demo-be")
 public interface BackendClient {
 
 	@GetMapping("/")

--- a/k8s-bff/src/main/resources/application.yml
+++ b/k8s-bff/src/main/resources/application.yml
@@ -1,9 +1,15 @@
-server:  port: 80
+server:
+  port: 80
 management:
-  server:    port: 8010  endpoints:
+  server:
+    port: 8010
+  endpoints:
     web:
       exposure:
         include: "*"
   endpoint:
     health:
       show-details: ALWAYS
+spring: 
+  application:
+    name: k8s-demo-bff

--- a/k8s-bff/src/main/resources/bootstrap.yml
+++ b/k8s-bff/src/main/resources/bootstrap.yml
@@ -1,3 +1,0 @@
-spring: 
-  application:
-    name: k8s-bff

--- a/k8s-deployment/a-namespaces-volumes.k8s.yml
+++ b/k8s-deployment/a-namespaces-volumes.k8s.yml
@@ -18,9 +18,36 @@ kind: PersistentVolume
 metadata:
   name: pv0001
 spec:
+  storageClassName: standard
   accessModes:
     - ReadWriteOnce
   capacity:
-    storage: 16Gi
+    storage: 1.5Gi
   hostPath:
-    path: /data/pv0001/
+    path: /data/pv000x/
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0002
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1.5Gi
+  hostPath:
+    path: /data/pv000x/
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0010
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /data/pv0010/

--- a/k8s-deployment/elasticsearch.k8s.yml
+++ b/k8s-deployment/elasticsearch.k8s.yml
@@ -22,7 +22,7 @@ metadata:
   namespace: k8s-logging
 spec:
   serviceName: elasticsearch
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: elasticsearch
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.2.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
         resources:
             limits:
               cpu: 1000m
@@ -57,9 +57,17 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           - name: discovery.seed_hosts
-            value: "es-cluster-0.elasticsearch,es-cluster-1.elasticsearch,es-cluster-2.elasticsearch"
+            value: "es-cluster-0.elasticsearch,es-cluster-1.elasticsearch"
           - name: cluster.initial_master_nodes
-            value: "es-cluster-0,es-cluster-1,es-cluster-2"
+            value: "es-cluster-0,es-cluster-1"
+          - name: cluster.routing.allocation.disk.watermark.low
+            value: 2.5gb
+          - name: cluster.routing.allocation.disk.watermark.high
+            value: 1.67gb
+          - name: cluster.routing.allocation.disk.watermark.flood_stage
+            value: .83gb
+          - name: node.max_local_storage_nodes
+            value: "2"
           - name: ES_JAVA_OPTS
             value: "-Xms512m -Xmx512m"
       initContainers:
@@ -87,7 +95,8 @@ spec:
       labels:
         app: elasticsearch
     spec:
+      storageClassName: standard
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 8Gi
+          storage: 1.5Gi

--- a/k8s-deployment/fluentd.k8s.yml
+++ b/k8s-deployment/fluentd.k8s.yml
@@ -91,7 +91,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:v1.9.3-debian-elasticsearch7-1.0
+        image: fluent/fluentd-kubernetes-daemonset:v1.18-debian-elasticsearch7-1
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elasticsearch.k8s-logging.svc.cluster.local"

--- a/k8s-deployment/grafana.k8s.yml
+++ b/k8s-deployment/grafana.k8s.yml
@@ -28,7 +28,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:6.7.2
+      - image: grafana/grafana:11.5.2
         name: grafana
         ports:
         - containerPort: 3000
@@ -42,8 +42,8 @@ spec:
           persistentVolumeClaim:
             claimName: grafana-storage
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
+        runAsNonRoot: false
+        runAsUser: 0
         fsGroup: 472
 ---
 apiVersion: v1
@@ -54,8 +54,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  ports:
-  - port: 3000
   selector:
     app: grafana
   type: NodePort  

--- a/k8s-deployment/kibana.k8s.yml
+++ b/k8s-deployment/kibana.k8s.yml
@@ -6,10 +6,12 @@ metadata:
   labels:
     app: kibana
 spec:
-  ports:
-  - port: 5601
+  type: NodePort
   selector:
     app: kibana
+  ports:
+  - port: 5601
+    nodePort: 30004
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -30,7 +32,7 @@ spec:
     spec:
       containers:
       - name: kibana
-        image: docker.elastic.co/kibana/kibana:7.2.0
+        image: docker.elastic.co/kibana/kibana:7.17.28
         resources:
           limits:
             cpu: 1000m
@@ -41,16 +43,3 @@ spec:
             value: http://elasticsearch:9200
         ports:
         - containerPort: 5601
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kibana
-  namespace: k8s-logging  
-spec:
-  type: NodePort
-  selector:
-    app: kibana
-  ports:
-  - port: 5601
-    nodePort: 30004

--- a/k8s-deployment/prometheus.ks8.yml
+++ b/k8s-deployment/prometheus.ks8.yml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -20,7 +20,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
@@ -187,7 +187,7 @@ spec:
     spec:
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.17.1
+          image: bitnami/prometheus:2.55.1
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"

--- a/k8s-deployment/spring-boot-apps.k8s.yml
+++ b/k8s-deployment/spring-boot-apps.k8s.yml
@@ -4,8 +4,11 @@ metadata:
   namespace: k8s-spring-boot-apps
   name: namespace-reader
 rules:
-  - apiGroups: ["", "extensions", "apps"]
-    resources: ["namespaces", "configmaps", "pods", "services", "endpoints", "secrets"]
+  - apiGroups: ["", "apps"]
+    resources: ["endpoints", "configmaps", "pods", "services"] # , "namespaces", "secrets"
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments"]
     verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding
@@ -21,32 +24,61 @@ subjects:
 roleRef:
   kind: Role
   name: namespace-reader
-  apiGroup: "rbac.authorization.k8s.io"
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8s-be
+  name: k8s-demo-be
   namespace: k8s-spring-boot-apps
 data:
   application.yml: |-
-    k8s-be:
-      message: "Message in a bottle"
+    spring:
+      application:
+        name: k8s-demo-be
+      cloud:
+        kubernetes:
+          reload:
+            enabled: true
+            mode: event
+    ---
+    spring:
+      config:
+        activate:
+          on-profile: development
+    k8s-demo:
+      be:
+        message: Development-specific config message
+        tip:
+          summary: "Development-specific tip: Did you know that Java HttpClient makes a new connection to server immediately after an IOException?"
+          learn-more-ref: https://github.com/haqer1/java-http-client-demo?tab=readme-ov-file#for-ioexception
+    ---
+    spring:
+      config:
+        activate:
+          on-profile: integration
+    k8s-demo:
+      be:
+        message: Integration-specific config message
+        tip:
+          summary: "Integration-specific tip: Did you know that Java HttpClient makes a new connection to server upon a new request following an HttpTimeoutException?"
+          learn-more-ref: https://github.com/haqer1/java-http-client-demo?tab=readme-ov-file#for-httptimeoutexception
+
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: k8s-be
+  name: k8s-demo-be
   namespace: k8s-spring-boot-apps
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: k8s-be
+      app: k8s-demo-be
   template:
     metadata:
       labels:
-        app: k8s-be
+        app: k8s-demo-be
         fluentd-log-format: spring-boot-json
       annotations:
            prometheus.io/scrape: 'true'
@@ -54,13 +86,19 @@ spec:
            prometheus.io/port: '8010'
     spec:
       containers:
-      - name: k8s-be-container
-        image: gcr.io/handy-zephyr-272321/k8s-be:1.0.2
+      - name: k8s-demo-be-container
+        image: docker.io/adazes/k8s-demo-be:1.3.19
         ports:
         - name: http-service
           containerPort: 80
         - name: http-management
           containerPort: 8010
+        env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: "development"
+        envFrom:
+        - configMapRef:
+            name: k8s-demo-be
         readinessProbe:
           httpGet:
             path: /actuator/health
@@ -73,34 +111,35 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: k8s-be
+  name: k8s-demo-be
   namespace: k8s-spring-boot-apps
   labels:
     sba-monitored: "true"
 spec:
   type: NodePort
   selector:
-    app: k8s-be
+    app: k8s-demo-be
   ports:
   - port: 80
     name: http-service
+    nodePort: 30001
   - port: 8010
     name: http-management
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: k8s-bff
+  name: k8s-demo-bff
   namespace: k8s-spring-boot-apps
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: k8s-bff
+      app: k8s-demo-bff
   template:
     metadata:
       labels:
-        app: k8s-bff
+        app: k8s-demo-bff
         fluentd-log-format: spring-boot-json
       annotations:
            prometheus.io/scrape: 'true'
@@ -108,8 +147,8 @@ spec:
            prometheus.io/port: '8010'
     spec:
       containers:
-      - name: k8s-bff-container
-        image: gcr.io/handy-zephyr-272321/k8s-bff:1.0.0
+      - name: k8s-demo-bff-container
+        image: docker.io/adazes/k8s-demo-bff:1.3.19
         ports:
         - name: http-service
           containerPort: 80
@@ -127,14 +166,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: k8s-bff
+  name: k8s-demo-bff
   namespace: k8s-spring-boot-apps
   labels:
     sba-monitored: "true"
 spec:
   type: NodePort
   selector:
-    app: k8s-bff
+    app: k8s-demo-bff
   ports:
   - port: 80
     name: http-service
@@ -145,7 +184,7 @@ spec:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: k8s-sba
+  name: k8s-demo-sba
   namespace: k8s-spring-boot-apps
 data:
   application.yml: |-
@@ -160,17 +199,17 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: k8s-sba
+  name: k8s-demo-sba
   namespace: k8s-spring-boot-apps
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: k8s-sba
+      app: k8s-demo-sba
   template:
     metadata:
       labels:
-        app: k8s-sba
+        app: k8s-demo-sba
         fluentd-log-format: spring-boot-json
       annotations:
            prometheus.io/scrape: 'true'
@@ -178,8 +217,8 @@ spec:
            prometheus.io/port: '8010'
     spec:
       containers:
-      - name: k8s-sba-container
-        image: gcr.io/handy-zephyr-272321/k8s-sba:1.0.0
+      - name: k8s-demo-sba-container
+        image: docker.io/adazes/k8s-demo-sba:1.3.19
         ports:
         - name: http-service
           containerPort: 80
@@ -197,14 +236,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: k8s-sba
+  name: k8s-demo-sba
   namespace: k8s-spring-boot-apps
   labels:
     sba-monitored: "true"
 spec:
   type: NodePort
   selector:
-    app: k8s-sba
+    app: k8s-demo-sba
   ports:
   - port: 80
     name: http-service

--- a/k8s-sba/pom.xml
+++ b/k8s-sba/pom.xml
@@ -6,24 +6,32 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.6.RELEASE</version>
-		<relativePath /> <!-- lookup parent from repository -->
+		<version>3.4.4</version>
+		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>ch.martin.k8s</groupId>
-	<artifactId>k8s-sba</artifactId>
-	<version>1.0.0</version>
-	<name>k8s-sba</name>
+	<artifactId>k8s-demo-sba</artifactId>
+	<version>1.3.19</version>
+	<name>k8s-demo-sba</name>
 	<description>Spring Boot Admin</description>
 
 	<properties>
-		<java.version>11</java.version>
-		<spring-boot-admin.version>2.2.2</spring-boot-admin.version>
+		<k8s-demo.image.hosting.account.url>docker.io/adazes</k8s-demo.image.hosting.account.url>
+
+		<java.version>21</java.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<spring-cloud.k8s.version>3.2.1</spring-cloud.k8s.version>
+		<logstash.version>8.0</logstash.version>
+		<lombok.version>1.18.36</lombok.version>
+		<git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
+		<spring-boot-admin.version>3.4.5</spring-boot-admin.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>de.codecentric</groupId>
 			<artifactId>spring-boot-admin-starter-server</artifactId>
+			<version>${spring-boot-admin.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -35,12 +43,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-kubernetes-all</artifactId>
+			<artifactId>spring-cloud-starter-kubernetes-client-all</artifactId>
+			<version>${spring-cloud.k8s.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
-			<version>6.3</version>
+			<version>${logstash.version}</version>
 		</dependency>
 
 		<dependency>
@@ -52,6 +61,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -79,7 +89,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Hoxton.RELEASE</version>
+				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -102,14 +112,19 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
+				<version>${git-commit-id-plugin.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-				<version>2.2.0</version>
+				<version>3.4.5</version>
 				<configuration>
 					<to>
-						<image>gcr.io/handy-zephyr-272321/${project.artifactId}:${project.version}</image>
+						<image>${k8s-demo.image.hosting.account.url}/${project.artifactId}:${project.version}</image>
+<!--						<auth>
+							<username>adazes</username>
+							<password><passwd/></password>
+						</auth>-->
 					</to>
 				</configuration>
 			</plugin>

--- a/k8s-sba/src/main/resources/application.yml
+++ b/k8s-sba/src/main/resources/application.yml
@@ -10,3 +10,6 @@ management:
   endpoint:
     health:
       show-details: ALWAYS
+spring:
+  application:
+    name: k8s-demo-sba

--- a/k8s-sba/src/main/resources/bootstrap.yml
+++ b/k8s-sba/src/main/resources/bootstrap.yml
@@ -1,3 +1,0 @@
-spring: 
-  application:
-    name: k8s-sba

--- a/k8s-sba/src/test/java/ch/martin/k8s/sba/BurnBabyBurnTests.java
+++ b/k8s-sba/src/test/java/ch/martin/k8s/sba/BurnBabyBurnTests.java
@@ -9,5 +9,4 @@ class BurnBabyBurnTests {
 	@Test
 	void contextLoads() {
 	}
-
 }


### PR DESCRIPTION
Upgrades, fix-ups, enhancements & tweaks (1st time in more than 4 years & 1 month)

 * update README.md (reducing --memory param, tweaking config notes, adding an endpoint, etc.)
   - the hostnames have been updated to begin with k8s-demo-, because it seems useful to indicate the demo nature in published image names & to keep the hostnames consistent with those
     -- BackendClient updated...
   - including fix-ups for 2 pre-existing typos
 * dependencies:
   - upgrade: Spring Boot (to 3.4.4) (spring-boot-admin: 3.4.5), Java (to 21), Spring Cloud (to 2024), logstash (to 8), jib-maven-plugin (to 3.4.5), as well as lombok, git-commit-id-plugin
   - add:
     -- commons-lang3, jakarta.validation-api, hibernate-validator
     -- k8s-demo.image.hosting.account.url property (related to image publication)
   - replace spring-cloud-starter-kubernetes-client-all w/ spring-cloud-starter-kubernetes-fabric8-config in -be modue (for on-the-fly ConfigMap-based config, etc.)
 * enhance:
   - GreetingDto
     -- private message
     -- added .appVersion, .now, .spring
   - GreetingController
     -- .buildProperties & .env
        --- update constructor to assign new properties & return enhanced GreetingDto
     -- log just the error message with ID & stack trace
 * add:
   - records:
     -- SpringInfoDto to group Spring-related data in response (for use by GreetingController)
     -- TipDto (structure for use by TipOfTheDayController)
   - MarkerPool: app-wide pool of markers
   - @RestController TipOfTheDayController class w/ example of logging w/ Marker
   - WEBM video
 * update:
   - @SpringBootApplication w/ @ComponentScan for detection of new @RestController
   - logback-spring.yml to log messages from io.fabric8 & org.springframework.cloud.kubernetes.fabric8 (useful for config troubleshooting)
 * delete bootstrap.yml files: deprecated in Spring Boot
   - merge their spring configs to application.yml files
     -- tweak message property & add k8s-demo.be.tip(.summary|.learn-more-ref)
 * fix up newlines in bff module's application.yml
 * in .yml:
   - a-namespaces-volumes.k8s.yml:
     -- for pv0001:
        --- add storageClassName: standard
        --- reduce capacity to 1.5Gi
        --- change path: /data/pv000x/
     -- add pv0002 (templated as pv0001) & pv0010
   - elasticsearch.k8s.yml:
     -- upgrade to v7.17.28
     -- update to:
        --- 2 replicas
        --- storageClassName: standard
        --- 1.5Gi
     -- add:
        --- cluster.routing.allocation.disk.watermark(.low|.high|.flood_stage) in GB
        --- node.max_local_storage_nodes
   - fluentd.k8s.yml: upgrade to v1.18
   - grafana.k8s.yml:
     -- upgrade to 11.5.2
     -- change to run as root
     -- delete duplicate spec.ports.port
   - kibana.k8s.yml:
     -- upgrade to 7.17.28
     -- merge 2 duplicate services
   - prometheus.ks8.yml:
     -- upgrade to 2.55.1 & rbac.authorization.k8s.io/v1
   - spring-boot-apps.k8s.yml:
     -- add:
        --- in config map:
            ---- k8s.reload.enabled...
            ---- 1 message & 2 tip properties specific to 2 profiles specified via spring.config.activate.on-profile
        --- in deployment:
            ---- SPRING_PROFILES_ACTIVE env. var.
            ---- envFrom.configMapRef.name
        --- in service:
            ---- nodePort: 30001

Thanks,
Resat